### PR TITLE
Adds new order single and excution report; changes default FIX versio…

### DIFF
--- a/lib/fix/protocol/message.rb
+++ b/lib/fix/protocol/message.rb
@@ -11,7 +11,7 @@ module Fix
     class Message < MessagePart
 
       # Default version for when we do not specify anything
-      DEFAULT_VERSION = 'FIX.4.4'
+      DEFAULT_VERSION = 'FIX.4.2'
       @@expected_version = DEFAULT_VERSION
 
       #

--- a/lib/fix/protocol/message_class_mapping.rb
+++ b/lib/fix/protocol/message_class_mapping.rb
@@ -13,11 +13,13 @@ module Fix
       MAPPING = {
         '0' => :heartbeat,
         'A' => :logon,
+        'D' => :new_order_single,
         '1' => :test_request,
         '2' => :resend_request,
         '3' => :reject,
         '4' => :sequence_reset,
         '5' => :logout,
+        '8' => :execution_report,
         'V' => :market_data_request,
         'W' => :market_data_snapshot,
         'X' => :market_data_incremental_refresh,

--- a/lib/fix/protocol/messages/execution_report.rb
+++ b/lib/fix/protocol/messages/execution_report.rb
@@ -1,0 +1,66 @@
+module Fix
+  module Protocol
+    module Messages
+      #
+      # A FIX execution report
+      #
+      class ExecutionReport < FP::Message
+
+        EXECUTION_TYPES = {
+          '0' => :new,
+          '1' => :partial_fill,
+          '2' => :filled,
+          '3' => :done_for_day,
+          '4' => :canceled,
+          '5' => :replace,
+          '6' => :pending_cancel,
+          '7' => :stopped,
+          '8' => :rejected,
+          '9' => :suspended,
+          'A' => :pending_new,
+          'B' => :calculated,
+          'C' => :expired,
+          'D' => :restated,
+          'E' => :pending_replace,
+        }
+
+        ORDER_STATUSES = {
+          '0' => :new,
+          '1' => :partially_filled,
+          '2' => :filled,
+          '3' => :done_for_day,
+          '4' => :canceled,
+          '5' => :replaced,
+          '6' => :pending_cancel,
+          '7' => :stopped,
+          '8' => :rejected,
+          '9' => :suspended,
+          'A' => :pending_new,
+          'B' => :calculated,
+          'C' => :expired,
+          'D' => :accepted_for_bidding,
+          'E' => :pending_replace,
+        }
+
+        TRANSACTION_TYPES = {
+          '0' => :new,
+          '1' => :cancel,
+          '2' => :correct,
+          '3' => :Status
+        }
+
+        unordered :body do
+          field :exec_trans_type, tag: 20,  mapping: TRANSACTION_TYPES
+          field :order_status,    tag: 39,  mapping: ORDER_STATUSES
+          field :exec_type,       tag: 150, mapping: EXECUTION_TYPES
+        end
+
+        def errors
+          errs = []
+          [super, errs].flatten
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fix/protocol/messages/logon.rb
+++ b/lib/fix/protocol/messages/logon.rb
@@ -10,7 +10,6 @@ module Fix
         unordered :body do
           field :encrypt_method,      tag: 98,  required: true, type: :integer, default: 0
           field :heart_bt_int,        tag: 108, required: true, type: :integer, default: 30
-          field :username,            tag: 553, required: true
           field :reset_seq_num_flag,  tag: 141,                 type: :yn_bool, default: false
         end
 
@@ -30,4 +29,3 @@ module Fix
     end
   end
 end
-

--- a/lib/fix/protocol/messages/new_order_single.rb
+++ b/lib/fix/protocol/messages/new_order_single.rb
@@ -1,0 +1,103 @@
+module Fix
+  module Protocol
+    module Messages
+      #
+      # A FIX new order single message
+      #
+      class NewOrderSingle < FP::Message
+
+        HANDLE_INSTRUCTIONS = {
+          auto_private: 1, # Automated execution order, private, no Broker intervention
+          auto_public:  2, # Automated execution order, public, Broker intervention OK
+          manual:       3  # Manual order, best execution
+        }
+
+        ID_SOURCES = {
+          cusip:       1,
+          sedol:       2,
+          quik:        3,
+          isin_number: 4,
+          ric_code:    5
+        }
+
+        IN_FORCE_TIMES = {
+          day: 0, # Day order, default
+          gtc: 1, # Good unTil Cancel
+          opg: 2, # At the opening
+          ioc: 3, # Immediate or cancel
+          fok: 4, # Fill or kill
+          gtx: 5, # Good unTil crossing
+          gtd: 6  # Good unTil date
+        }
+
+        ORDER_TYPES = {
+          market: '1',
+          limit: '2',
+          stop: '3',
+          stop_limit: '4',
+          market_on_close: '5',
+          with_or_without: '6',
+          limit_or_better: '7',
+          limit_with_or_without: '8',
+          on_basis: '9',
+          on_close: 'A',
+          limit_on_close: 'B',
+          forex_market: 'C',
+          previously_quoted: 'D',
+          previously_indicated: 'E',
+          forex_limit: 'F',
+          forex_swap: 'G',
+          forex_previously_quoted: 'H',
+          funari: 'I',
+          pegged: 'P'
+        }
+
+        RULES_80 = {
+          agency_single_order: 'A'
+        }
+
+        SETTLEMENT_TYPES = {
+          regular: '0',
+          cash: '1',
+          next_day: '2'
+        }
+
+        SIDES = {
+          buy: 1,
+          sell: 2
+        }
+
+        unordered :body do
+          field :cl_ord_id,         tag: 11,  required: true
+          field :handl_inst,        tag: 21,  required: true, type: :integer, mapping: HANDLE_INSTRUCTIONS
+          field :ord_type,          tag: 40,  required: true, mapping: ORDER_TYPES
+          field :symbol,            tag: 55,  required: true
+          field :side,              tag: 54,  required: true, type: :integer, mapping: SIDES
+          field :transact_time,     tag: 60,  required: true, type: :timestamp, default: proc { Time.now }
+          field :account,           tag: 1
+          field :currency,          tag: 15
+          field :id_source,         tag: 22,  type: :integer, mapping: ID_SOURCES
+          field :order_qty,         tag: 38,  type: :float
+          field :price,             tag: 44,  type: :float
+          field :rule_80_a,         tag: 47,  mapping: RULES_80
+          field :security_id,       tag: 48
+          field :text,              tag: 58
+          field :time_in_force,     tag: 59,  type: :integer, mapping: IN_FORCE_TIMES
+          field :settlmnt_typ,      tag: 63,  mapping: SETTLEMENT_TYPES
+          field :min_qty,           tag: 110, type: :float
+          field :max_floor,         tag: 111, type: :float
+          field :security_type,     tag: 167
+          field :security_exchange, tag: 207
+          field :compliance_id,     tag: 376
+          field :clearing_account,  tag: 440
+        end
+
+        def errors
+          errs = []
+          [super, errs].flatten
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
Initial changes to the fix-protocol gem to:
* Change the default version to 4.2
* Change the Logon message class not to require username
* Add New Order Single and Execution Report message types